### PR TITLE
Ensure the cli reads the weights file correctly

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -80,7 +80,8 @@ function loadJSONModel(modelPath: string) {
             }
             model.weightSpecs.push(...group.weights);
         }
-        model.weightData = Buffer.concat(buffers).buffer;
+        const weightDataBuf = Buffer.concat(buffers)
+        model.weightData = weightDataBuf.buffer.slice(weightDataBuf.byteOffset, weightDataBuf.byteOffset+weightDataBuf.byteLength);
     }
 
     return model;


### PR DESCRIPTION
If the model is small, it's possible that the buffers for the model and weights are stored in a single underlying ArrayBuffer, so when we access this with `Buffer.buffer` we incorrectly read the text of the JSON model as it's own weights.